### PR TITLE
Add shortcuts to focus or swap tile with next or previous tile

### DIFF
--- a/contents/code/tilingmanager.js
+++ b/contents/code/tilingmanager.js
@@ -421,7 +421,7 @@ function TilingManager() {
                               });
         KWin.registerShortcut("TILING: Focus next tile",
                               "Focus next tile",
-                              "Meta+Control+N",
+                              "Meta+]",
                               function() {
                                   try {
                                       var layout = self.layouts[workspace.currentDesktop - 1][workspace.activeScreen];
@@ -446,7 +446,7 @@ function TilingManager() {
                               });
         KWin.registerShortcut("TILING: Focus previous tile",
                               "Focus previous tile",
-                              "Meta+Control+P",
+                              "Meta+[",
                               function() {
                                   try {
                                       var layout = self.layouts[workspace.currentDesktop - 1][workspace.activeScreen];
@@ -471,7 +471,7 @@ function TilingManager() {
                               });
         KWin.registerShortcut("TILING: Swap with next tile",
                               "Swap with next tile",
-                              "Meta+Control+Shift+N",
+                              "Meta+Shift+]",
                               function() {
                                   try {
                                       var layout = self.layouts[workspace.currentDesktop - 1][workspace.activeScreen];
@@ -496,7 +496,7 @@ function TilingManager() {
                               });
         KWin.registerShortcut("TILING: Swap with previous tile",
                               "Swap with previous tile",
-                              "Meta+Control+Shift+P",
+                              "Meta+Shift+[",
                               function() {
                                   try {
                                       var layout = self.layouts[workspace.currentDesktop - 1][workspace.activeScreen];

--- a/contents/code/tilingmanager.js
+++ b/contents/code/tilingmanager.js
@@ -419,6 +419,106 @@ function TilingManager() {
                                       print(err, "in Decrease-Number-Of-Masters");
                                   }
                               });
+        KWin.registerShortcut("TILING: Focus next tile",
+                              "Focus next tile",
+                              "Meta+Control+N",
+                              function() {
+                                  try {
+                                      var layout = self.layouts[workspace.currentDesktop - 1][workspace.activeScreen];
+                                      if (layout != null) {
+                                          var client = workspace.activeClient;
+                                          if (client != null) {
+                                              var tile = layout.getTile(client.x, client.y);
+                                          }
+                                      }
+                                      if (tile != null) {
+                                          var index1 = layout.tiles.indexOf(tile);
+                                          if (index1 == layout.tiles.length-1) {
+                                              var index2 = 0;
+                                          } else {
+                                              var index2 = index1 + 1;
+                                          } 
+                                          workspace.activeClient = layout.tiles[index2].clients[0];
+                                      }
+                                  } catch(err) {
+                                      print(err, "in focus-next-tile");
+                                  }
+                              });
+        KWin.registerShortcut("TILING: Focus previous tile",
+                              "Focus previous tile",
+                              "Meta+Control+P",
+                              function() {
+                                  try {
+                                      var layout = self.layouts[workspace.currentDesktop - 1][workspace.activeScreen];
+                                      if (layout != null) {
+                                          var client = workspace.activeClient;
+                                          if (client != null) {
+                                              var tile = layout.getTile(client.x, client.y);
+                                          }
+                                      }
+                                      if (tile != null) {
+                                          var index1 = layout.tiles.indexOf(tile);
+                                          if (index1 == 0) {
+                                              var index2 = layout.tiles.length-1;
+                                          } else {
+                                              var index2 = index1 - 1;
+                                          } 
+                                          workspace.activeClient = layout.tiles[index2].clients[0];
+                                      }
+                                  } catch(err) {
+                                      print(err, "in focus-previous-tile");
+                                  }
+                              });
+        KWin.registerShortcut("TILING: Swap with next tile",
+                              "Swap with next tile",
+                              "Meta+Control+Shift+N",
+                              function() {
+                                  try {
+                                      var layout = self.layouts[workspace.currentDesktop - 1][workspace.activeScreen];
+                                      if (layout != null) {
+                                          var client = workspace.activeClient;
+                                          if (client != null) {
+                                              var tile = layout.getTile(client.x, client.y);
+                                          }
+                                      }
+                                      if (tile != null) {
+                                          var index1 = layout.tiles.indexOf(tile);
+                                          if (index1 == layout.tiles.length-1) {
+                                              var index2 = 0;
+                                          } else {
+                                              var index2 = index1 + 1;
+                                          } 
+                                          layout.swapTiles(tile, layout.tiles[index2]);
+                                      }
+                                  } catch(err) {
+                                      print(err, "in swap-with-next-tile");
+                                  }
+                              });
+        KWin.registerShortcut("TILING: Swap with previous tile",
+                              "Swap with previous tile",
+                              "Meta+Control+Shift+P",
+                              function() {
+                                  try {
+                                      var layout = self.layouts[workspace.currentDesktop - 1][workspace.activeScreen];
+                                      if (layout != null) {
+                                          var client = workspace.activeClient;
+                                          if (client != null) {
+                                              var tile = layout.getTile(client.x, client.y);
+                                          }
+                                      }
+                                      if (tile != null) {
+                                          var index1 = layout.tiles.indexOf(tile);
+                                          if (index1 == 0) {
+                                              var index2 = layout.tiles.length-1;
+                                          } else {
+                                              var index2 = index1 - 1;
+                                          } 
+                                          layout.swapTiles(tile, layout.tiles[index2]);
+                                      }
+                                  } catch(err) {
+                                      print(err, "in swap-with-previous-tile");
+                                  }
+                              });
     }
     // registerUserActionsMenu(function(client) {
     //     return {


### PR DESCRIPTION
Many tiling window managers (awesome, bluetile, etc.) have these shortcuts. Previously, kwin-tiling only had support for swapping or changing focus up/down/left/right. Native kwin Alt-tab switching does not always cycle through tiles in order and doesn't support swapping.
