### PR TITLE
Revert "Remove maximization handling"

### DIFF
--- a/contents/code/tile.js
+++ b/contents/code/tile.js
@@ -405,6 +405,27 @@ Tile.prototype.addClient = function(client) {
     }
 };
 
+Tile.prototype.onClientMaximizedStateChanged = function(client, h, v) {
+    try {
+        // Set keepBelow to keep maximized clients over tiled ones
+        // TODO: We don't distinguish between horizontal and vertical maximization,
+        // also there's no way to find that the _user_ caused this.
+        // So we might want to ignore maximization entirely.
+        if (h || v) {
+            client.keepBelow = false;
+            // We might get a geometryChanged signal before this
+            // so we need to manually maximize the client.
+            client.tiling_resize = true;
+            client.geometry = workspace.clientArea(KWin.MaximizeFullArea, this._currentScreen, this._currentDesktop);
+            client.tiling_resize = false;
+        } else {
+            client.keepBelow = true;
+        }
+    } catch(err) {
+        print(err, "in tile.onClientMaximizedStateChanged");
+    }
+};
+
 Tile.prototype.hasClient = function(client) {
     return (this.clients.indexOf(client) > -1);
 };

--- a/contents/code/tilelist.js
+++ b/contents/code/tilelist.js
@@ -202,6 +202,12 @@ TileList.prototype.connectSignals = function(client) {
             print(err, "in activeChanged");
         }
     });
+    client.clientMaximizedStateChanged.connect(function(client, h, v) {
+        var tile = self.getTile(client);
+        if (tile != null) {
+            tile.onClientMaximizedStateChanged(client, h, v);
+        }
+    });
     client.tiling_connected2 = true;
 };
 /**

--- a/doc/tiling-classdiagram.txt
+++ b/doc/tiling-classdiagram.txt
@@ -66,6 +66,7 @@ class Tile {
 	+onClientKeepBelowChanged(client)
 	+onClientFullScreenChanged(client)
 	+onClientMinimizedChanged(client)
+	+onClientMaximizedStateChanged(client, h, v)
 	+onClientDesktopChanged(client)
 	+onClientStartUserMovedResized(client)
 	+onClientStepUserMovedResized(client)


### PR DESCRIPTION
This reverts commit 25252744db18752079a86fc5e0e5a53f5bd32c32.

Back in 2017, the maximization handling was broken
- windows maximizing when they shouldn't
- showing up as maximized (via the window button) even though no signal
was fired.

This seems to be resolved now. Successfully tested with
- Kwin 5.12 / KDE Frameworks 5.45.0
- Doubleclicking title bar / maximize button / KWin keyboard shortcut
- Unmaximize (clicking again the maximize button) correctly gets back to the layout before maximization