### PR TITLE
Improvements and bug fixes for i3Layout and HalfLayout

### DIFF
--- a/contents/code/containerTree.js
+++ b/contents/code/containerTree.js
@@ -41,6 +41,24 @@ function ContainerNode(type, rect) {
 }
 
 /*
+ * Update sizes for this container and all children-containers as a bottom-up operation
+ */
+ContainerNode.prototype.updateContainerSizes = function() {
+
+    this.children.forEach(function (child) {
+        if (child.children) child.updateContainerSizes();
+    });
+
+    if (this.children[0]) {
+        var rect = this.children[0].rectangle;
+        this.children.forEach(function (child) {
+            rect = util.expandRect(rect, child.rectangle);
+        });
+        this.rectangle = util.copyRect(rect);
+    }
+};
+
+/*
  * Recalculate sizes for this node as a top-down operation
  */
 ContainerNode.prototype.recalculateSize = function() {
@@ -79,7 +97,6 @@ ContainerNode.prototype.recalculateSize = function() {
 ContainerNode.prototype.addNode = function(node, index) {
     this.children.splice(index, 0, node);
     node.parent = this;
-    this.recalculateSize();
 };
 
 /*
@@ -88,7 +105,6 @@ ContainerNode.prototype.addNode = function(node, index) {
  */
 ContainerNode.prototype.removeNode = function(node) {
     this.children = this.children.filter(function (x) {return x !== node;});
-    this.recalculateSize();
 };
 
 /*

--- a/contents/code/halflayout.js
+++ b/contents/code/halflayout.js
@@ -50,7 +50,7 @@ HalfLayout.prototype.addTile = function() {
             util.assertRectInScreen(rect, this.screenRectangle);
             this._createTile(rect);
             return;
-        } 
+        }
         if (this.tiles.length <= this.masterCount) {
             // The second tile fills the right half of the screen
             if (this.tiles.length < this.masterCount) {
@@ -236,9 +236,16 @@ HalfLayout.prototype.decrementMaster = function() {
     } else {
         var oldMWidth = this.getMasterWidth();
     }
-    if (this.tiles.length >= oldC) {
+    if (this.tiles.length > oldC) {
         var newMWidth = oldMWidth / newC;
-        var newSWidth = this.screenRectangle.width - oldMWidth;
+        if(newC == 0) {
+            newMWidth = 0;
+        }
+        var newSWidth = this.screenRectangle.width - (newMWidth * newC);
+        var newSHeight = this.screenRectangle.height / (this.tiles.length - newC);
+    } else if (this.tiles.length == oldC) {
+        var newMWidth = oldMWidth / oldC;
+        var newSWidth = this.screenRectangle.width - (newMWidth * newC);
         var newSHeight = this.screenRectangle.height / (this.tiles.length - newC);
     } else {
         var newMWidth = this.screenRectangle.width / this.tiles.length;
@@ -254,9 +261,11 @@ HalfLayout.prototype.decrementMaster = function() {
         this.tiles[i].rectangle.y = this.screenRectangle.y + (i - newC) * newSHeight;
         this.tiles[i].rectangle.height = newSHeight;
         this.tiles[i].rectangle.width = newSWidth;
-        this.tiles[i].rectangle.x = this.screenRectangle.x + oldMWidth;
+        this.tiles[i].rectangle.x = this.screenRectangle.x + (newMWidth * newC);
         util.assertRectInScreen(this.tiles[i].rectangle, this.screenRectangle);
     }
     this.masterCount--;
-    this.firstWidth = this.getMasterWidth();
+    if(newC != 0) {
+        this.firstWidth = this.getMasterWidth();
+    }
 };

--- a/contents/code/halflayout.js
+++ b/contents/code/halflayout.js
@@ -140,7 +140,11 @@ HalfLayout.prototype.removeTile = function(tileIndex) {
             var mC = Math.min(this.tiles.length, this.masterCount);
             if (this.tiles.length > mC) {
                 // The distance between the right edge of the last master and the left edge of the screen is the width of the master area
-                var mWidth = (this.tiles[mC - 1].rectangle.x + this.tiles[mC - 1].rectangle.width - this.screenRectangle.x) / mC;
+                if(mC > 0){
+                    var mWidth = (this.tiles[mC - 1].rectangle.x + this.tiles[mC - 1].rectangle.width - this.screenRectangle.x) / mC;
+                } else {
+                    var mWidth = 0;
+                }
             } else {
                 var mWidth = this.screenRectangle.width / this.tiles.length;
             }
@@ -267,5 +271,7 @@ HalfLayout.prototype.decrementMaster = function() {
     this.masterCount--;
     if(newC != 0) {
         this.firstWidth = this.getMasterWidth();
+    } else {
+        this.firstWidth = this.screenRectangle.width / 2;
     }
 };

--- a/contents/code/halflayout.js
+++ b/contents/code/halflayout.js
@@ -248,7 +248,7 @@ HalfLayout.prototype.decrementMaster = function() {
         var newSWidth = this.screenRectangle.width - (newMWidth * newC);
         var newSHeight = this.screenRectangle.height / (this.tiles.length - newC);
     } else if (this.tiles.length == oldC) {
-        var newMWidth = oldMWidth / oldC;
+        var newMWidth = (this.screenRectangle.width / 2) / newC ;
         var newSWidth = this.screenRectangle.width - (newMWidth * newC);
         var newSHeight = this.screenRectangle.height / (this.tiles.length - newC);
     } else {

--- a/contents/code/i3layout.js
+++ b/contents/code/i3layout.js
@@ -108,6 +108,9 @@ I3Layout.prototype.addTile = function(x, y) {
           }
         */
 
+        // update all container sizes according to their children's sizes
+        this.containerTree.updateContainerSizes();
+
         // Create the new tile
         // TODO: Cleanup: Common parts in both if branches
         if (this.state === 'normal') {
@@ -117,12 +120,13 @@ I3Layout.prototype.addTile = function(x, y) {
             this._createTile(leaf.rectangle);
             var tile = this.tiles[this.tiles.length - 1];
             selectedContainer.children[childIndex] = tile;
+            selectedContainer.recalculateSize();
         }
         else if (this.state === 'horizontalWrap' ||
                    this.state === 'verticalWrap') {
 
             // Wrap mode: wrap selected tile in a new container and append new tile there
-            var wrapContainer = new ContainerNode(this.state === 'horizontalWrap' ? 'horizontal' : 'vertical');
+            var wrapContainer = new ContainerNode(this.state === 'horizontalWrap' ? 'horizontal' : 'vertical',util.copyRect(selectedTile.rectangle));
             selectedContainer.addNode(wrapContainer, childIndex);
             selectedContainer.removeNode(selectedTile);
             wrapContainer.addNode(selectedTile, 0);
@@ -132,6 +136,7 @@ I3Layout.prototype.addTile = function(x, y) {
             this._createTile(leaf.rectangle);
             var tile = this.tiles[this.tiles.length - 1];
             wrapContainer.children[1] = tile;
+            wrapContainer.recalculateSize();
         }
 
         this.state = 'normal';
@@ -160,10 +165,12 @@ I3Layout.prototype.removeTile = function(tileIndex) {
         var toDeleteTile = this.tiles[tileIndex];
         var container = this.containerTree.findParentContainer(toDeleteTile);
 
+        this.containerTree.updateContainerSizes();
         container.removeNode(toDeleteTile);
-        this.containerTree.cleanup();
-        this.containerTree.recalculateSize();
         this.tiles.splice(tileIndex, 1);
+        container.recalculateSize();
+
+        this.containerTree.cleanup();
 
         print(debugPrintTree(this.containerTree));
 

--- a/contents/code/i3layout.js
+++ b/contents/code/i3layout.js
@@ -91,8 +91,12 @@ I3Layout.prototype.addTile = function(x, y) {
         if (!selectedTile) this.state = 'normal';
 
         // Also ignore attempts to wrap a container inside a container
-        if (selectedContainer && this.state !== 'normal' && selectedContainer.children.length <= 1)
+        if (selectedContainer && this.state !== 'normal' && selectedContainer.children.length <= 1) {
+            if (selectedContainer === this.containerTree) {
+                this.containerTree.type = (this.state === 'horizontalWrap' ? 'horizontal' : 'vertical');
+            }
             this.state = 'normal';
+        }
 
         /*
           //NOTE: I'll leave this here just in case someone wants to enable it.

--- a/contents/code/tilelist.js
+++ b/contents/code/tilelist.js
@@ -491,7 +491,7 @@ TileList.prototype.trackFocusChanges = function(focusedClient) {
                 focusedClient = clients[0];
             }
         }
-        if (focusedClient && (focusedClient != this.focusHistory.current)) {
+        if (focusedClient && ((focusedClient != this.focusHistory.current) || !this.focusHistory.previous)) {
             this.focusHistory.previous = this.focusHistory.current;
             this.focusHistory.current = focusedClient;
             //print('Focused:' + focusedClient.caption);

--- a/contents/code/tilelist.js
+++ b/contents/code/tilelist.js
@@ -491,7 +491,7 @@ TileList.prototype.trackFocusChanges = function(focusedClient) {
                 focusedClient = clients[0];
             }
         }
-        if (focusedClient) {
+        if (focusedClient && (focusedClient != this.focusHistory.current)) {
             this.focusHistory.previous = this.focusHistory.current;
             this.focusHistory.current = focusedClient;
             //print('Focused:' + focusedClient.caption);

--- a/contents/code/util.js
+++ b/contents/code/util.js
@@ -60,6 +60,15 @@ util.intersectRect = function(rect1, rect2) {
     return newRect;
 };
 
+util.expandRect = function(rect1, rect2) {
+    var newRect = Qt.rect(0,0,0,0);
+    newRect.x = Math.min(rect1.x, rect2.x);
+    newRect.y = Math.min(rect1.y, rect2.y);
+    newRect.width = (Math.max(rect1.x + rect1.width, rect2.x + rect2.width) - newRect.x);
+    newRect.height = (Math.max(rect1.y + rect1.height, rect2.y + rect2.height) - newRect.y);
+    return newRect;
+};
+
 util.setX = function(geom, value) {
     geom.width = (geom.width + geom.x) - value;
     geom.x = value;


### PR DESCRIPTION
This implements some bugfixes and new features for the i3Layout and the HalfLayout.

i3Layout:

- now tiles keep their sizes when removing or creating new tiles.

- the wrap-orientation of the root container can now be changed with the Meta+v and Meta+b shortcuts

- fixed a bug where the layout created tiles in wrong places because the focusHistory was wrong: for some reason on my machine a window  when focused was put two times into the focusHistory instead of once.

HalfLayout:

- After all tiles were slaves when increasing master count to 1, the master will take half of the page instead of having width 0 as before. Same with all master tiles.

- When all tiles are slaves, tiles are now resized after a tile is deleted. #121 
