### PR TITLE
Improvements and Bugfixes for i3Layout and Halflayout

### DIFF
--- a/contents/code/containerTree.js
+++ b/contents/code/containerTree.js
@@ -41,6 +41,24 @@ function ContainerNode(type, rect) {
 }
 
 /*
+ * Update sizes for this container and all children-containers as a bottom-up operation
+ */
+ContainerNode.prototype.updateContainerSizes = function() {
+
+    this.children.forEach(function (child) {
+        if (child.children) child.updateContainerSizes();
+    });
+
+    if (this.children[0]) {
+        var rect = this.children[0].rectangle;
+        this.children.forEach(function (child) {
+            rect = util.expandRect(rect, child.rectangle);
+        });
+        this.rectangle = util.copyRect(rect);
+    }
+};
+
+/*
  * Recalculate sizes for this node as a top-down operation
  */
 ContainerNode.prototype.recalculateSize = function() {
@@ -79,7 +97,6 @@ ContainerNode.prototype.recalculateSize = function() {
 ContainerNode.prototype.addNode = function(node, index) {
     this.children.splice(index, 0, node);
     node.parent = this;
-    this.recalculateSize();
 };
 
 /*
@@ -88,7 +105,6 @@ ContainerNode.prototype.addNode = function(node, index) {
  */
 ContainerNode.prototype.removeNode = function(node) {
     this.children = this.children.filter(function (x) {return x !== node;});
-    this.recalculateSize();
 };
 
 /*

--- a/contents/code/containerTree.js
+++ b/contents/code/containerTree.js
@@ -59,36 +59,116 @@ ContainerNode.prototype.updateContainerSizes = function() {
 };
 
 /*
- * Recalculate sizes for this node as a top-down operation
+ * Resize this node and its children as a top-down operation
+ * Keep size ratio of children
  */
-ContainerNode.prototype.recalculateSize = function() {
+ContainerNode.prototype.resizeNode = function(rectAfter) {
 
-    var r = this.rectangle;
+    var rectBefore = this.rectangle;
+    this.rectangle = util.copyRect(rectAfter);
+    var childrenLength = this.children.length;
+
 
     if (this.type === 'horizontal') {
-        var newWidth = r.width / this.children.length;
+
+        var totalWidth = 0;
+        var newWidth = 0;
 
         this.children.forEach(function(child, index) {
-            child.rectangle.x = r.x + index*newWidth;
-            child.rectangle.y = r.y;
-            child.rectangle.width = newWidth;
-            child.rectangle.height = r.height;
-            if (child.children) child.recalculateSize();
+            var newRect = Qt.rect(0, 0, 0, 0);
+            if (index === childrenLength - 1) {
+                newWidth = Math.floor(rectAfter.width - totalWidth);
+            } else {
+                newWidth = Math.floor((child.rectangle.width / rectBefore.width) * rectAfter.width);
+            }
 
+            newRect.x = rectAfter.x + totalWidth;
+            newRect.y = rectAfter.y;
+            newRect.width = newWidth;
+            newRect.height = rectAfter.height;
+            totalWidth += newWidth;
+            if(child.children) child.resizeNode(util.copyRect(newRect));
+            else child.rectangle = util.copyRect(newRect);
         });
 
     } else if (this.type === 'vertical') {
-        var newHeight = r.height / this.children.length;
+
+        var totalHeight = 0;
+        var newHeight = 0;
 
         this.children.forEach(function(child, index) {
-            child.rectangle.x = r.x;
-            child.rectangle.y = r.y + index*newHeight;
-            child.rectangle.width = r.width;
-            child.rectangle.height = newHeight;
-            if (child.children) child.recalculateSize();
+            var newRect = Qt.rect(0, 0, 0, 0);
+            if (index === childrenLength - 1) {
+                newHeight = Math.floor(rectAfter.height - totalHeight);
+            } else {
+                newHeight = Math.floor((child.rectangle.height / rectBefore.height) * rectAfter.height);
+            }
+
+            newRect.x = rectAfter.x;
+            newRect.y = rectAfter.y + totalHeight;
+            newRect.width = rectAfter.width;
+            newRect.height = newHeight;
+            totalHeight += newHeight;
+            if(child.children) child.resizeNode(util.copyRect(newRect));
+            else child.rectangle = util.copyRect(newRect);
         });
     }
+};
 
+/*
+ * Recalculate sizes for this nodes children as a top-down operation
+ * give all children the same size
+ */
+ContainerNode.prototype.recalculateSize = function() {
+
+    var rectBefore = this.rectangle;
+    var childrenLength = this.children.length;
+
+
+    if (this.type === 'horizontal') {
+
+        var totalWidth = 0;
+        var newWidth = 0;
+
+        this.children.forEach(function(child, index) {
+            var newRect = Qt.rect(0, 0, 0, 0);
+            if (index === childrenLength - 1) {
+                newWidth = Math.floor(rectBefore.width - totalWidth);
+            } else {
+                newWidth = Math.floor(rectBefore.width / childrenLength);
+            }
+
+            newRect.x = rectBefore.x + totalWidth;
+            newRect.y = rectBefore.y;
+            newRect.width = newWidth;
+            newRect.height = rectBefore.height;
+            totalWidth += newWidth;
+            if(child.children) child.resizeNode(util.copyRect(newRect));
+            else child.rectangle = util.copyRect(newRect);
+        });
+
+    } else if (this.type === 'vertical') {
+
+        var totalHeight = 0;
+        var newHeight = 0;
+
+        this.children.forEach(function(child, index) {
+            var newRect = Qt.rect(0, 0, 0, 0);
+            if (index === childrenLength - 1) {
+                newHeight = Math.floor(rectBefore.height - totalHeight);
+            } else {
+                newHeight = Math.floor(rectBefore.height / childrenLength);
+            }
+
+            newRect.x = rectBefore.x;
+            newRect.y = rectBefore.y + totalHeight;
+            newRect.width = rectBefore.width;
+            newRect.height = newHeight;
+            totalHeight += newHeight;
+            if(child.children) child.resizeNode(util.copyRect(newRect));
+            else child.rectangle = util.copyRect(newRect);
+        });
+    }
 };
 
 /*

--- a/contents/code/halflayout.js
+++ b/contents/code/halflayout.js
@@ -165,9 +165,6 @@ HalfLayout.prototype.removeTile = function(tileIndex) {
             // Fallthrough for slaves
         }
         if (this.tiles.length > this.masterCount) {
-            if (tileIndex == 0) {
-                this.tiles[0].rectangle = oldrect;
-            }
             var tileCount = this.tiles.length - this.masterCount;
             util.assertTrue(tileCount > 0, "Tilecount is zero");
             var lastRect = this.tiles[0].rectangle;

--- a/contents/code/halflayout.js
+++ b/contents/code/halflayout.js
@@ -57,6 +57,7 @@ HalfLayout.prototype.addTile = function() {
                 var newWidth = this.screenRectangle.width / (this.tiles.length + 1);
                 var newSWidth = newWidth;
             } else {
+                this.firstWidth = this.screenRectangle.width / 2;
                 var newWidth = this.firstWidth / (this.tiles.length);
                 var newSWidth = this.screenRectangle.width - this.firstWidth;
             }
@@ -141,7 +142,14 @@ HalfLayout.prototype.removeTile = function(tileIndex) {
             if (this.tiles.length > mC) {
                 // The distance between the right edge of the last master and the left edge of the screen is the width of the master area
                 if(mC > 0){
-                    var mWidth = (this.tiles[mC - 1].rectangle.x + this.tiles[mC - 1].rectangle.width - this.screenRectangle.x) / mC;
+                    if(tileIndex === mC - 1){
+                        var mWidth = (oldrect.x + oldrect.width - this.screenRectangle.x) / mC;
+                    }
+                    else if(tileIndex < mC - 1){
+                        var mWidth = (this.tiles[mC - 2].rectangle.x + this.tiles[mC - 2].rectangle.width - this.screenRectangle.x) / mC;
+                    }else {
+                        var mWidth = (this.tiles[mC - 1].rectangle.x + this.tiles[mC - 1].rectangle.width - this.screenRectangle.x) / mC;
+                    }
                 } else {
                     var mWidth = 0;
                 }

--- a/contents/code/halflayout.js
+++ b/contents/code/halflayout.js
@@ -50,7 +50,7 @@ HalfLayout.prototype.addTile = function() {
             util.assertRectInScreen(rect, this.screenRectangle);
             this._createTile(rect);
             return;
-        } 
+        }
         if (this.tiles.length <= this.masterCount) {
             // The second tile fills the right half of the screen
             if (this.tiles.length < this.masterCount) {
@@ -236,9 +236,16 @@ HalfLayout.prototype.decrementMaster = function() {
     } else {
         var oldMWidth = this.getMasterWidth();
     }
-    if (this.tiles.length >= oldC) {
+    if (this.tiles.length > oldC) {
         var newMWidth = oldMWidth / newC;
-        var newSWidth = this.screenRectangle.width - oldMWidth;
+        if(newC == 0) {
+            newMWidth = 0;
+        }
+        var newSWidth = this.screenRectangle.width - (newMWidth * newC);
+        var newSHeight = this.screenRectangle.height / (this.tiles.length - newC);
+    } else if (this.tiles.length == oldC) {
+        var newMWidth = oldMWidth / oldC;
+        var newSWidth = this.screenRectangle.width - (newMWidth * newC);
         var newSHeight = this.screenRectangle.height / (this.tiles.length - newC);
     } else {
         var newMWidth = this.screenRectangle.width / this.tiles.length;
@@ -254,9 +261,11 @@ HalfLayout.prototype.decrementMaster = function() {
         this.tiles[i].rectangle.y = this.screenRectangle.y + (i - newC) * newSHeight;
         this.tiles[i].rectangle.height = newSHeight;
         this.tiles[i].rectangle.width = newSWidth;
-        this.tiles[i].rectangle.x = this.screenRectangle.x + oldMWidth;
+        this.tiles[i].rectangle.x = this.screenRectangle.x + (newMWidth * newC);
         util.assertRectInScreen(this.tiles[i].rectangle, this.screenRectangle);
     }
     this.masterCount--;
-    this.firstWidth = this.getMasterWidth();
+    if(newC != 0) {
+        this.firstWidth = this.getMasterWidth();
+    }
 };

--- a/contents/code/halflayout.js
+++ b/contents/code/halflayout.js
@@ -140,7 +140,11 @@ HalfLayout.prototype.removeTile = function(tileIndex) {
             var mC = Math.min(this.tiles.length, this.masterCount);
             if (this.tiles.length > mC) {
                 // The distance between the right edge of the last master and the left edge of the screen is the width of the master area
-                var mWidth = (this.tiles[mC - 1].rectangle.x + this.tiles[mC - 1].rectangle.width - this.screenRectangle.x) / mC;
+                if(mC > 0){
+                    var mWidth = (this.tiles[mC - 1].rectangle.x + this.tiles[mC - 1].rectangle.width - this.screenRectangle.x) / mC;
+                } else {
+                    var mWidth = 0;
+                }
             } else {
                 var mWidth = this.screenRectangle.width / this.tiles.length;
             }
@@ -267,5 +271,7 @@ HalfLayout.prototype.decrementMaster = function() {
     this.masterCount--;
     if(newC != 0) {
         this.firstWidth = this.getMasterWidth();
+    } else {
+        this.firstWidth = this.screenRectangle.width / 2;
     }
 };

--- a/contents/code/halflayout.js
+++ b/contents/code/halflayout.js
@@ -248,7 +248,7 @@ HalfLayout.prototype.decrementMaster = function() {
         var newSWidth = this.screenRectangle.width - (newMWidth * newC);
         var newSHeight = this.screenRectangle.height / (this.tiles.length - newC);
     } else if (this.tiles.length == oldC) {
-        var newMWidth = oldMWidth / oldC;
+        var newMWidth = (this.screenRectangle.width / 2) / newC ;
         var newSWidth = this.screenRectangle.width - (newMWidth * newC);
         var newSHeight = this.screenRectangle.height / (this.tiles.length - newC);
     } else {

--- a/contents/code/i3layout.js
+++ b/contents/code/i3layout.js
@@ -108,6 +108,9 @@ I3Layout.prototype.addTile = function(x, y) {
           }
         */
 
+        // update all container sizes according to their children's sizes
+        this.containerTree.updateContainerSizes();
+
         // Create the new tile
         // TODO: Cleanup: Common parts in both if branches
         if (this.state === 'normal') {
@@ -117,12 +120,13 @@ I3Layout.prototype.addTile = function(x, y) {
             this._createTile(leaf.rectangle);
             var tile = this.tiles[this.tiles.length - 1];
             selectedContainer.children[childIndex] = tile;
+            selectedContainer.recalculateSize();
         }
         else if (this.state === 'horizontalWrap' ||
                    this.state === 'verticalWrap') {
 
             // Wrap mode: wrap selected tile in a new container and append new tile there
-            var wrapContainer = new ContainerNode(this.state === 'horizontalWrap' ? 'horizontal' : 'vertical');
+            var wrapContainer = new ContainerNode(this.state === 'horizontalWrap' ? 'horizontal' : 'vertical',util.copyRect(selectedTile.rectangle));
             selectedContainer.addNode(wrapContainer, childIndex);
             selectedContainer.removeNode(selectedTile);
             wrapContainer.addNode(selectedTile, 0);
@@ -132,6 +136,7 @@ I3Layout.prototype.addTile = function(x, y) {
             this._createTile(leaf.rectangle);
             var tile = this.tiles[this.tiles.length - 1];
             wrapContainer.children[1] = tile;
+            wrapContainer.recalculateSize();
         }
 
         this.state = 'normal';
@@ -160,10 +165,12 @@ I3Layout.prototype.removeTile = function(tileIndex) {
         var toDeleteTile = this.tiles[tileIndex];
         var container = this.containerTree.findParentContainer(toDeleteTile);
 
+        this.containerTree.updateContainerSizes();
         container.removeNode(toDeleteTile);
-        this.containerTree.cleanup();
-        this.containerTree.recalculateSize();
         this.tiles.splice(tileIndex, 1);
+        container.recalculateSize();
+
+        this.containerTree.cleanup();
 
         print(debugPrintTree(this.containerTree));
 

--- a/contents/code/i3layout.js
+++ b/contents/code/i3layout.js
@@ -91,8 +91,12 @@ I3Layout.prototype.addTile = function(x, y) {
         if (!selectedTile) this.state = 'normal';
 
         // Also ignore attempts to wrap a container inside a container
-        if (selectedContainer && this.state !== 'normal' && selectedContainer.children.length <= 1)
+        if (selectedContainer && this.state !== 'normal' && selectedContainer.children.length <= 1) {
+            if (selectedContainer === this.containerTree) {
+                this.containerTree.type = (this.state === 'horizontalWrap' ? 'horizontal' : 'vertical');
+            }
             this.state = 'normal';
+        }
 
         /*
           //NOTE: I'll leave this here just in case someone wants to enable it.

--- a/contents/code/tilelist.js
+++ b/contents/code/tilelist.js
@@ -491,7 +491,7 @@ TileList.prototype.trackFocusChanges = function(focusedClient) {
                 focusedClient = clients[0];
             }
         }
-        if (focusedClient && (focusedClient != this.focusHistory.current)) {
+        if (focusedClient && ((focusedClient != this.focusHistory.current) || !this.focusHistory.previous)) {
             this.focusHistory.previous = this.focusHistory.current;
             this.focusHistory.current = focusedClient;
             //print('Focused:' + focusedClient.caption);

--- a/contents/code/tilelist.js
+++ b/contents/code/tilelist.js
@@ -491,7 +491,7 @@ TileList.prototype.trackFocusChanges = function(focusedClient) {
                 focusedClient = clients[0];
             }
         }
-        if (focusedClient) {
+        if (focusedClient && (focusedClient != this.focusHistory.current)) {
             this.focusHistory.previous = this.focusHistory.current;
             this.focusHistory.current = focusedClient;
             //print('Focused:' + focusedClient.caption);

--- a/contents/code/tilingmanager.js
+++ b/contents/code/tilingmanager.js
@@ -555,6 +555,20 @@ function TilingManager() {
                                       print(err, "in i3-layout-set-wrap-vertical-mode");
                                   }
                               });
+        KWin.registerShortcut("TILING-I3: Set Normal Mode",
+                              "Set Normal Mode",
+                              "Meta+N",
+                              function() {
+                                  try {
+                                      var layout = self.layouts[workspace.currentDesktop - 1][workspace.activeScreen];
+                                      if (layout != null && layout.layout.isI3Layout) {
+                                          layout.layout.state = 'normal';
+                                      }
+
+                                  } catch(err) {
+                                      print(err, "in i3-layout-set-normal-mode");
+                                  }
+                              });
     }
     // registerUserActionsMenu(function(client) {
     //     return {

--- a/contents/code/util.js
+++ b/contents/code/util.js
@@ -60,6 +60,15 @@ util.intersectRect = function(rect1, rect2) {
     return newRect;
 };
 
+util.expandRect = function(rect1, rect2) {
+    var newRect = Qt.rect(0,0,0,0);
+    newRect.x = Math.min(rect1.x, rect2.x);
+    newRect.y = Math.min(rect1.y, rect2.y);
+    newRect.width = (Math.max(rect1.x + rect1.width, rect2.x + rect2.width) - newRect.x);
+    newRect.height = (Math.max(rect1.y + rect1.height, rect2.y + rect2.height) - newRect.y);
+    return newRect;
+};
+
 util.setX = function(geom, value) {
     geom.width = (geom.width + geom.x) - value;
     geom.x = value;


### PR DESCRIPTION
This implements some bugfixes and new features for the i3Layout and the HalfLayout.

i3Layout:

- now tiles keep their sizes when removing or creating new tiles instead of resetting all tile sizes to default

- also children of resized containers keep their size ratio

- the wrap-orientation of the root container can now be changed with the Meta+V and Meta+B shortcuts

- new shortcut Meta+N lets you go back to "normal" mode from one of the wrap modes

- fixed a bug where the layout created tiles in the wrong location because the focusHistory was broken: for some reason on my machine a window  when focused was put two times into the focusHistory instead of once.

HalfLayout:

- After all tiles were slaves when increasing master count to 1, the master will take half of the page instead of having width 0 as before.

- After all n tiles were masters when decreasing master count to n-1, the new slave will take half of the page instead of having width 0 as before.

- When all tiles are slaves, tiles are now resized after a tile is deleted. #121 

- fixed bug that gave a newly created tile width 0 when there were n tiles and mastercount was n before creation.

- fixed bug where tile resizing was broken when deleting one of multiple master tiles